### PR TITLE
Fix the type of the method option in README.md (object => string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const submitData = async () => {
 | Option     | Type    | Required | Default   | Description                                         |
 |:-----------|:--------|----------|-----------|-----------------------------------------------------|
 | `url`      | String  | ✅ Yes    | undefined | API endpoint to sync data                           |
-| `method`   | Object  | ❌ No     | "POST"    | HTTP method (e.g., "POST", "PUT", etc.)             |
+| `method`   | String  | ❌ No     | "POST"    | HTTP method (e.g., "POST", "PUT", etc.)             |
 | `headers`  | Object  | ❌ No     | {}        | Additional headers (e.g., authentication token)     |
 | `keyPath`  | String  | ❌ No     | "id"      | The unique key for storing data in IndexedDB        |
 | `bulkSync` | Boolean | ❌ No     | false     | Set to true if your API accepts batch sync requests |


### PR DESCRIPTION
As can be seen [here][1], the `method` option is of type `string` (not `object`). This change updates the README to reflect that.

[1]: https://github.com/jrran90/vue-offline-sync/blob/v1.0.2/src/vue-offline-sync.ts#L10